### PR TITLE
Specify locale to decimal format

### DIFF
--- a/jfuzzylite/src/main/java/com/fuzzylite/FuzzyLite.java
+++ b/jfuzzylite/src/main/java/com/fuzzylite/FuzzyLite.java
@@ -49,7 +49,7 @@ public class FuzzyLite {
         }
     }
 
-    private static final ThreadLocal<DecimalFormat> FORMATTER = new ThreadSafeDecimalFormat();
+    private static final ThreadSafeDecimalFormat FORMATTER = new ThreadSafeDecimalFormat();
 
     public static final Charset UTF_8 = Charset.forName("UTF-8");
 

--- a/jfuzzylite/src/main/java/com/fuzzylite/FuzzyLite.java
+++ b/jfuzzylite/src/main/java/com/fuzzylite/FuzzyLite.java
@@ -44,6 +44,7 @@ public class FuzzyLite {
         protected DecimalFormat initialValue() {
             NumberFormat df = NumberFormat.getNumberInstance(Locale.ROOT);
             df.setMinimumFractionDigits(decimals);
+            df.setMaximumFractionDigits(decimals);
             return (DecimalFormat) df;
         }
     }
@@ -126,6 +127,7 @@ public class FuzzyLite {
         FuzzyLite.decimals = decimals;
         DecimalFormat decimalFormat = FORMATTER.get();
         decimalFormat.setMinimumFractionDigits(decimals);
+        decimalFormat.setMaximumFractionDigits(decimals);
     }
 
     /**

--- a/jfuzzylite/src/main/java/com/fuzzylite/FuzzyLite.java
+++ b/jfuzzylite/src/main/java/com/fuzzylite/FuzzyLite.java
@@ -19,6 +19,8 @@ package com.fuzzylite;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
@@ -40,11 +42,13 @@ public class FuzzyLite {
 
         @Override
         protected DecimalFormat initialValue() {
-            return new DecimalFormat("0.000");
+            NumberFormat df = NumberFormat.getNumberInstance(Locale.ROOT);
+            df.setMinimumFractionDigits(decimals);
+            return (DecimalFormat) df;
         }
     }
 
-    private static final ThreadSafeDecimalFormat FORMATTER = new ThreadSafeDecimalFormat();
+    private static final ThreadLocal<DecimalFormat> FORMATTER = new ThreadSafeDecimalFormat();
 
     public static final Charset UTF_8 = Charset.forName("UTF-8");
 
@@ -120,12 +124,8 @@ public class FuzzyLite {
      */
     public static void setDecimals(int decimals) {
         FuzzyLite.decimals = decimals;
-        StringBuilder pattern = new StringBuilder("0.".length() + decimals);
-        pattern.append("0.");
-        for (int i = 0; i < decimals; ++i) {
-            pattern.append('0');
-        }
-        FORMATTER.set(new DecimalFormat(pattern.toString()));
+        DecimalFormat decimalFormat = FORMATTER.get();
+        decimalFormat.setMinimumFractionDigits(decimals);
     }
 
     /**


### PR DESCRIPTION
FunctionTest#testFunctionArithmetic failed on my machine which uses Finnish locale by default.

I don't know if ROOT is good for default but atleast it fixed the tests.  

Also calling FORMATTER.set had the effect that initialValue of the ThreadLocal was never called. 