### PR TITLE
Failing test in rule addition

### DIFF
--- a/jfuzzylite/src/main/java/com/fuzzylite/rule/Rule.java
+++ b/jfuzzylite/src/main/java/com/fuzzylite/rule/Rule.java
@@ -99,6 +99,13 @@ public class Rule implements Op.Cloneable {
         this(text, 1.0);
     }
 
+    /**
+     *
+     * @param text the rule text
+     * @param weight Not considered at all. Use `with N` in rule text to specify weight.
+     *
+     * @deprecated Use Rule(String) instead. This constructor will be made private in a later release.
+     */
     public Rule(String text, double weight) {
         this.enabled = true;
         this.text = text;

--- a/jfuzzylite/src/test/java/com/fuzzylite/rule/RuleWeightTest.java
+++ b/jfuzzylite/src/test/java/com/fuzzylite/rule/RuleWeightTest.java
@@ -1,0 +1,91 @@
+package com.fuzzylite.rule;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.fuzzylite.Console;
+import com.fuzzylite.Engine;
+
+public class RuleWeightTest {
+
+    private static final int NEW_RULE_INDEX = 3;
+    private static String RULE_TEXT = "if ambient is DARK then power is HIGH";
+
+
+
+    @Test
+    public void testAddRuleWithWeightUsingParse() throws Exception {
+        Engine engine = Console.mamdani();
+
+        RuleBlock ruleBlock = engine.getRuleBlock(0);
+        ruleBlock.addRule(Rule.parse(RULE_TEXT + " with 0.5", engine));
+
+        Assert.assertThat(ruleBlock.getRule(NEW_RULE_INDEX).getText(), startsWith(RULE_TEXT));
+        Assert.assertThat(ruleBlock.getRule(NEW_RULE_INDEX).getWeight(), is(0.5));
+    }
+
+    @Test
+    public void testAddRuleWithWeightInRule() throws Exception {
+        Engine engine = Console.mamdani();
+
+        RuleBlock ruleBlock = engine.getRuleBlock(0);
+
+        Rule rule = new Rule(RULE_TEXT, 0.5);
+
+        ruleBlock.addRule(rule);
+        rule.load(engine);
+
+        Assert.assertThat(ruleBlock.getRule(NEW_RULE_INDEX).getText(), startsWith(RULE_TEXT));
+        Assert.assertThat(ruleBlock.getRule(NEW_RULE_INDEX).getWeight(), is(0.5));
+    }
+
+    @Test
+    public void testAddRuleWithWeightInRuleText() throws Exception {
+        Engine engine = Console.mamdani();
+
+        RuleBlock ruleBlock = engine.getRuleBlock(0);
+
+        Rule rule = new Rule(RULE_TEXT + " with 0.5");
+
+        ruleBlock.addRule(rule);
+        rule.load(engine);
+
+        Assert.assertThat(ruleBlock.getRule(NEW_RULE_INDEX).getText(), startsWith(RULE_TEXT));
+        Assert.assertThat(ruleBlock.getRule(NEW_RULE_INDEX).getWeight(), is(0.5));
+
+    }
+
+    @Test
+    public void testRuleChangeWeight() throws Exception {
+        Engine engine = Console.mamdani();
+
+        RuleBlock ruleBlock = engine.getRuleBlock(0);
+
+        ruleBlock.getRule(0).setWeight(0.3);
+
+        Assert.assertThat(ruleBlock.getRule(0).getWeight(), is(0.3));
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+}

--- a/jfuzzylite/src/test/java/com/fuzzylite/rule/RuleWeightTest.java
+++ b/jfuzzylite/src/test/java/com/fuzzylite/rule/RuleWeightTest.java
@@ -2,6 +2,7 @@ package com.fuzzylite.rule;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.core.IsNot.not;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -18,29 +19,12 @@ public class RuleWeightTest {
     private static final int NEW_RULE_INDEX = 3;
     private static String RULE_TEXT = "if ambient is DARK then power is HIGH";
 
-
-
     @Test
     public void testAddRuleWithWeightUsingParse() throws Exception {
         Engine engine = Console.mamdani();
 
         RuleBlock ruleBlock = engine.getRuleBlock(0);
         ruleBlock.addRule(Rule.parse(RULE_TEXT + " with 0.5", engine));
-
-        Assert.assertThat(ruleBlock.getRule(NEW_RULE_INDEX).getText(), startsWith(RULE_TEXT));
-        Assert.assertThat(ruleBlock.getRule(NEW_RULE_INDEX).getWeight(), is(0.5));
-    }
-
-    @Test
-    public void testAddRuleWithWeightInRule() throws Exception {
-        Engine engine = Console.mamdani();
-
-        RuleBlock ruleBlock = engine.getRuleBlock(0);
-
-        Rule rule = new Rule(RULE_TEXT, 0.5);
-
-        ruleBlock.addRule(rule);
-        rule.load(engine);
 
         Assert.assertThat(ruleBlock.getRule(NEW_RULE_INDEX).getText(), startsWith(RULE_TEXT));
         Assert.assertThat(ruleBlock.getRule(NEW_RULE_INDEX).getWeight(), is(0.5));
@@ -63,14 +47,18 @@ public class RuleWeightTest {
     }
 
     @Test
-    public void testRuleChangeWeight() throws Exception {
+    public void testRuleWeightChange() throws Exception {
         Engine engine = Console.mamdani();
 
         RuleBlock ruleBlock = engine.getRuleBlock(0);
 
+        Assert.assertThat(ruleBlock.getRule(0).getWeight(), not(0.3));
+
         ruleBlock.getRule(0).setWeight(0.3);
 
         Assert.assertThat(ruleBlock.getRule(0).getWeight(), is(0.3));
+
+        //TODO: How to assert that the engine is in the same state that it would be if the rule started with weight 0.3?
     }
 
     @BeforeClass


### PR DESCRIPTION
Specifying rule weight was also something that I found a bit confusing. This pull request contains a failing test for setting rule weight in the rule object directly. Also couple of other test that seem to work. Changing the weight and asserting that the changed weight is actually used is something that might be missing from the last test.